### PR TITLE
evt_cmd bugfixes & added EVT_PATCH_END, UNCHECKED_USER_FUNC

### DIFF
--- a/ttyd-tools/rel/include/evt_cmd.h
+++ b/ttyd-tools/rel/include/evt_cmd.h
@@ -7,10 +7,6 @@
 #define EVT_END() \
 	0x1 };
 
-// For ending an array of evt commands without an "end" op; e.g. patching
-// commands over the middle of an existing event.  Should not be generally used.
-#define EVT_PATCH_END() } ;
-
 #define EVT_HELPER_OP(op) \
 	reinterpret_cast<int32_t>((op))
 
@@ -296,7 +292,7 @@ using evt_helper_int_array = int32_t[];
     
 // User function calls with unchecked parameter counts.
 // (Alternative to using the EVT_DECLARE_USER_FUNC macro w/-1)
-#define UNCHECKED_USER_FUNC(function, ...) \
+#define USER_FUNC_UNSAFE(function, ...) \
 	EVT_HELPER_CMD(1 + EVT_HELPER_NUM_ARGS(__VA_ARGS__), 91), \
 	reinterpret_cast<int32_t>(function), \
 	##__VA_ARGS__ ,

--- a/ttyd-tools/rel/include/evt_cmd.h
+++ b/ttyd-tools/rel/include/evt_cmd.h
@@ -7,6 +7,10 @@
 #define EVT_END() \
 	0x1 };
 
+// For ending an array of evt commands without an "end" op; e.g. patching
+// commands over the middle of an existing event.  Should not be generally used.
+#define EVT_PATCH_END() } ;
+
 #define EVT_HELPER_OP(op) \
 	reinterpret_cast<int32_t>((op))
 
@@ -78,10 +82,10 @@
 #define DO_CONTINUE() \
 	EVT_HELPER_CMD(0, 8),
 
-#define WAIT_FRM() \
-	EVT_HELPER_CMD(1, 9),
-#define WAIT_MSEC() \
-	EVT_HELPER_CMD(1, 10),
+#define WAIT_FRM(frm) \
+	EVT_HELPER_CMD(1, 9), EVT_HELPER_OP(frm),
+#define WAIT_MSEC(msec) \
+	EVT_HELPER_CMD(1, 10), EVT_HELPER_OP(msec),
 #define HALT(until) \
 	EVT_HELPER_CMD(1, 11), EVT_HELPER_OP(until),
 
@@ -135,9 +139,9 @@
 	EVT_HELPER_CMD(0, 33),
 
 #define SWITCH(val) \
-	EVT_HELPER_CMD(1, 34), EVT_HELPER_OP(val)
+	EVT_HELPER_CMD(1, 34), EVT_HELPER_OP(val),
 #define SWITCHI(val) \
-	EVT_HELPER_CMD(1, 35), EVT_HELPER_OP(val)
+	EVT_HELPER_CMD(1, 35), EVT_HELPER_OP(val),
 
 #define CASE_EQUAL(val) \
 	EVT_HELPER_CMD(1, 36), EVT_HELPER_OP(val),
@@ -177,34 +181,25 @@
 #define SETF(lhs, rhs) \
 	EVT_HELPER_CMD(2, 52), EVT_HELPER_OP(lhs), EVT_HELPER_OP(rhs),
 
-#define ADD(out, lhs, rhs) \
-	EVT_HELPER_CMD(3, 53), EVT_HELPER_OP(out), EVT_HELPER_OP(lhs), \
-	EVT_HELPER_OP(rhs),
-#define SUB(out, lhs, rhs) \
-	EVT_HELPER_CMD(3, 54), EVT_HELPER_OP(out), EVT_HELPER_OP(lhs), \
-	EVT_HELPER_OP(rhs),
-#define MUL(out, lhs, rhs) \
-	EVT_HELPER_CMD(3, 55), EVT_HELPER_OP(out), EVT_HELPER_OP(lhs), \
-	EVT_HELPER_OP(rhs),
-#define DIV(out, lhs, rhs) \
-	EVT_HELPER_CMD(3, 56), EVT_HELPER_OP(out), EVT_HELPER_OP(lhs), \
-	EVT_HELPER_OP(rhs),
-#define MOD(out, lhs, rhs) \
-	EVT_HELPER_CMD(3, 57), EVT_HELPER_OP(out), EVT_HELPER_OP(lhs), \
-	EVT_HELPER_OP(rhs),
+#define ADD(lhs, rhs) \
+	EVT_HELPER_CMD(2, 53), EVT_HELPER_OP(lhs), EVT_HELPER_OP(rhs),
+#define SUB(lhs, rhs) \
+	EVT_HELPER_CMD(2, 54), EVT_HELPER_OP(lhs), EVT_HELPER_OP(rhs),
+#define MUL(lhs, rhs) \
+	EVT_HELPER_CMD(2, 55), EVT_HELPER_OP(lhs), EVT_HELPER_OP(rhs),
+#define DIV(lhs, rhs) \
+	EVT_HELPER_CMD(2, 56), EVT_HELPER_OP(lhs), EVT_HELPER_OP(rhs),
+#define MOD(lhs, rhs) \
+	EVT_HELPER_CMD(2, 57), EVT_HELPER_OP(lhs), EVT_HELPER_OP(rhs),
 
-#define ADDF(out, lhs, rhs) \
-	EVT_HELPER_CMD(3, 58), EVT_HELPER_OP(out), EVT_HELPER_OP(lhs), \
-	EVT_HELPER_OP(rhs),
-#define SUBF(out, lhs, rhs) \
-	EVT_HELPER_CMD(3, 59), EVT_HELPER_OP(out), EVT_HELPER_OP(lhs), \
-	EVT_HELPER_OP(rhs),
-#define MULF(out, lhs, rhs) \
-	EVT_HELPER_CMD(3, 60), EVT_HELPER_OP(out), EVT_HELPER_OP(lhs), \
-	EVT_HELPER_OP(rhs),
-#define DIVF(out, lhs, rhs) \
-	EVT_HELPER_CMD(3, 61), EVT_HELPER_OP(out), EVT_HELPER_OP(lhs), \
-	EVT_HELPER_OP(rhs),
+#define ADDF(lhs, rhs) \
+	EVT_HELPER_CMD(2, 58), EVT_HELPER_OP(lhs), EVT_HELPER_OP(rhs),
+#define SUBF(lhs, rhs) \
+	EVT_HELPER_CMD(2, 59), EVT_HELPER_OP(lhs), EVT_HELPER_OP(rhs),
+#define MULF(lhs, rhs) \
+	EVT_HELPER_CMD(2, 60), EVT_HELPER_OP(lhs), EVT_HELPER_OP(rhs),
+#define DIVF(lhs, rhs) \
+	EVT_HELPER_CMD(2, 61), EVT_HELPER_OP(lhs), EVT_HELPER_OP(rhs),
 
 #define SET_READ(val) \
 	EVT_HELPER_CMD(1, 62), EVT_HELPER_OP(val),
@@ -265,9 +260,9 @@
 #define SET_RAMF(val, ptr) \
 	EVT_HELPER_CMD(2, 84), EVT_HELPER_OP(val), EVT_HELPER_OP(ptr),
 #define GET_RAM(val, ptr) \
-	EVT_HELPER_CMD(2, 85), EVT_HELPER_OP(out), EVT_HELPER_OP(ptr),
+	EVT_HELPER_CMD(2, 85), EVT_HELPER_OP(val), EVT_HELPER_OP(ptr),
 #define GET_RAMF(val, ptr) \
-	EVT_HELPER_CMD(2, 86), EVT_HELPER_OP(out), EVT_HELPER_OP(ptr),
+	EVT_HELPER_CMD(2, 86), EVT_HELPER_OP(val), EVT_HELPER_OP(ptr),
 
 // R is short for Reg
 #define SETR(indirect, val) \
@@ -296,6 +291,13 @@ using evt_helper_int_array = int32_t[];
 		>(), \
 		EVT_HELPER_CMD(1 + EVT_HELPER_NUM_ARGS(__VA_ARGS__), 91) \
 	), \
+	reinterpret_cast<int32_t>(function), \
+	##__VA_ARGS__ ,
+    
+// User function calls with unchecked parameter counts.
+// (Alternative to using the EVT_DECLARE_USER_FUNC macro w/-1)
+#define UNCHECKED_USER_FUNC(function, ...) \
+	EVT_HELPER_CMD(1 + EVT_HELPER_NUM_ARGS(__VA_ARGS__), 91), \
 	reinterpret_cast<int32_t>(function), \
 	##__VA_ARGS__ ,
 
@@ -329,8 +331,8 @@ using evt_helper_int_array = int32_t[];
 	EVT_HELPER_CMD(1, 104), EVT_HELPER_OP(evt_id),
 #define START_ID(evt_id) \
 	EVT_HELPER_CMD(1, 105), EVT_HELPER_OP(evt_id),
-#define CHK_EVT(evt_id) \
-	EVT_HELPER_CMD(1, 106), EVT_HELPER_OP(evt_id),
+#define CHK_EVT(evt_id, is_running) \
+	EVT_HELPER_CMD(2, 106), EVT_HELPER_OP(evt_id), EVT_HELPER_OP(is_running),
 
 #define INLINE_EVT() \
 	EVT_HELPER_CMD(0, 107),


### PR DESCRIPTION
Ported changes to rel/include/evt_cmd.h from Infinite Pit; mostly bug fixes, but a couple of added macros:

- UNCHECKED_USER_FUNC (as an alternative to USER_FUNC when the number of arguments cannot be specified, e.g. when calling into relocatable code)
- EVT_PATCH_END (ends an array of evt commands without the "end" operator; could be useful for patching over part of an existing event without ending it prematurely).