### PR TITLE
elf2rel: Add support for linking against other rels

### DIFF
--- a/ttyd-tools/elf2rel/elf2rel.cpp
+++ b/ttyd-tools/elf2rel/elf2rel.cpp
@@ -62,15 +62,23 @@ std::map<std::string, SymbolLocation> loadSymbolMap(const std::string &filename)
 
 			std::string moduleIdStr = locInfo.substr(0, commaIndex1);
 			if (moduleIdStr.substr(0, 2) == "0x")
+			{
 				moduleId = std::stoul(moduleIdStr.substr(2), nullptr, 16);
+			}
 			else
+			{
 				moduleId = std::stoul(moduleIdStr, nullptr, 10);
+			}
 
 			std::string sectionIdStr = locInfo.substr(commaIndex1 + 1, commaIndex2 - commaIndex1);
 			if (sectionIdStr.substr(0, 2) == "0x")
+			{
 				sectionId = std::stoul(sectionIdStr.substr(2), nullptr, 16);
+			}
 			else
+			{
 				sectionId = std::stoul(sectionIdStr, nullptr, 10);
+			}
 
 			std::string addrStr = locInfo.substr(commaIndex2 + 1);
 			addr = std::stoul(addrStr, nullptr, 16);
@@ -445,9 +453,13 @@ int main(int argc, char **argv)
 	auto getModuleDelay = [moduleID](uint32_t id)
 	{
 		if (id == 0 || id == moduleID)
+		{
 			return 1;
+		}
 		else
+		{
 			return 0;
+		}
 	};
 
 	// Sort relocations
@@ -458,7 +470,9 @@ int main(int argc, char **argv)
 		int delayLeft = getModuleDelay(left.moduleID);
 		int delayRight = getModuleDelay(right.moduleID);
 		if (delayLeft != delayRight)
+		{
 			return delayLeft < delayRight;
+		}
 		
 		return std::tuple<uint32_t, uint32_t, uint32_t>(left.moduleID, left.section, left.offset)
 			   < std::tuple<uint32_t, uint32_t, uint32_t>(right.moduleID, right.section, right.offset);
@@ -539,7 +553,9 @@ int main(int argc, char **argv)
 			// If the next module ID was forced to the back and the current one wasn't,
 			// then this is the end of the relocations included in the fixed size
 			if (getModuleDelay(nextRel.moduleID) > getModuleDelay(currentModuleID))
+			{
 				fixedRelocationsSize = outputBuffer.size() - relocationOffset;
+			}
 
 			currentModuleID = nextRel.moduleID;
 			currentSectionIndex = -1;
@@ -594,7 +610,9 @@ int main(int argc, char **argv)
 	// If the final module referenced isn't forced to the back, then all
 	// relocations must be included in the fixed size
 	if (getModuleDelay(currentModuleID) == 0)
+	{
 		fixedRelocationsSize = outputBuffer.size() - relocationOffset;
+	}
 
 	// Write final import infos
 	int importInfoSize = importInfoBuffer.size();

--- a/ttyd-tools/elf2rel/elf2rel.cpp
+++ b/ttyd-tools/elf2rel/elf2rel.cpp
@@ -55,7 +55,7 @@ std::map<std::string, SymbolLocation> loadSymbolMap(const std::string &filename)
 		if (dol)
 			moduleId = 0;
 		else
-			moduleId = strtoul(line.substr(index2 + 1, index3).c_str(), nullptr, 10);
+			moduleId = strtoul(line.substr(index2 + 1, index3 - (index2 + 1)).c_str(), nullptr, 10);
 
 		uint32_t sectionId;
 		if (dol)

--- a/ttyd-tools/elf2rel/elf2rel.cpp
+++ b/ttyd-tools/elf2rel/elf2rel.cpp
@@ -49,7 +49,7 @@ std::map<std::string, SymbolLocation> loadSymbolMap(const std::string &filename)
 		// Handle comma separators, if present
 		// Commas can be included in mangled symbol names, so this has to be limited to before the name
 		std::string locInfo = line.substr(0, colonIndex);
-		size_t commaIndex1 = line.find_first_of(',');
+		size_t commaIndex1 = locInfo.find_first_of(',');
 		if (commaIndex1 == std::string::npos)
 		{
 			moduleId = 0;
@@ -58,7 +58,7 @@ std::map<std::string, SymbolLocation> loadSymbolMap(const std::string &filename)
 		}
 		else
 		{
-			size_t commaIndex2 = line.find_first_of(',', commaIndex1 + 1);
+			size_t commaIndex2 = locInfo.find_first_of(',', commaIndex1 + 1);
 
 			std::string moduleIdStr = locInfo.substr(0, commaIndex1);
 			if (moduleIdStr.substr(0, 2) == "0x")

--- a/ttyd-tools/elf2rel/elf2rel.cpp
+++ b/ttyd-tools/elf2rel/elf2rel.cpp
@@ -30,9 +30,15 @@ void trimAll(std::vector<std::string> &strs)
 
 bool parseInt(const std::string &str, uint32_t &out, int base=0)
 {
-	size_t len;
-	out = std::stoul(str, &len, base);
-	return len == str.length();
+	try {
+		size_t len;
+		out = std::stoul(str, &len, base);
+		return len == str.length();
+	}
+	catch (std::invalid_argument)
+	{
+		return false;
+	}
 }
 
 // dol symbols: addr:symbolName

--- a/ttyd-tools/elf2rel/elf2rel.cpp
+++ b/ttyd-tools/elf2rel/elf2rel.cpp
@@ -36,7 +36,7 @@ std::map<std::string, SymbolLocation> loadSymbolMap(const std::string &filename)
 		}
 
 		// dol symbols:    addr:symbolName
-		// rel symbols:    addr:symbolName?moduleId,sectionId
+		// rel symbols:    offset:symbolName?moduleId,sectionId
 		size_t index = line.find_first_of(':'); // addr-name separator
 		size_t index2 = line.find_first_of('?', index); // name-module separator
 		size_t index3 = line.find_first_of(',', index2); // module-section separator

--- a/ttyd-tools/elf2rel/elf2rel.cpp
+++ b/ttyd-tools/elf2rel/elf2rel.cpp
@@ -53,15 +53,31 @@ std::map<std::string, SymbolLocation> loadSymbolMap(const std::string &filename)
 
 		uint32_t moduleId;
 		if (dol)
+		{
 			moduleId = 0;
+		}
 		else
-			moduleId = strtoul(line.substr(index2 + 1, index3 - (index2 + 1)).c_str(), nullptr, 10);
+		{
+			std::string moduleIdStr = line.substr(index2 + 1, index3 - (index2 + 1));
+			if (moduleIdStr.substr(0, 2) == "0x")
+				moduleId = strtoul(moduleIdStr.substr(2).c_str(), nullptr, 16);
+			else
+				moduleId = strtoul(moduleIdStr.c_str(), nullptr, 10);
+		}
 
 		uint32_t sectionId;
 		if (dol)
+		{
 			sectionId = 0;
+		}
 		else
-			sectionId = strtoul(line.substr(index3 + 1).c_str(), nullptr, 10);
+		{
+			std::string sectionIdStr = line.substr(index3 + 1);
+			if (sectionIdStr.substr(0, 2) == "0x")
+				sectionId = strtoul(sectionIdStr.substr(2).c_str(), nullptr, 16);
+			else
+				sectionId = strtoul(sectionIdStr.c_str(), nullptr, 10);
+		}
 
 		outputMap[name] = { moduleId, sectionId, addr };
 	}

--- a/ttyd-tools/elf2rel/elf2rel.h
+++ b/ttyd-tools/elf2rel/elf2rel.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include <stdint.h>
 
 enum RelRelocationType
 {


### PR DESCRIPTION
Symbols for other rel modules can now be added to lst files with the syntax ~~`addr:symbolName?moduleId,sectionId` (see [here](https://github.com/SeekyCt/spm-practice-codes/blob/4592a3a7f1dbc97fe9ad146646fae4614fa49b0e/include/spm.eu0.lst#L417) for an example of it in use)~~
**Edit**: syntax is now `module,section,offset:name` (see [here](https://github.com/SeekyCt/spm-practice-codes/blob/f524a330c5291226a8bc8016d72ac78c57d124ba/include/spm.eu0.lst#L663) for an example) (the old syntax for dol symbols is still supported also)